### PR TITLE
Ensure merge.sh gets upstream branch when not found local

### DIFF
--- a/jdk8u/createNextTag.sh
+++ b/jdk8u/createNextTag.sh
@@ -36,7 +36,7 @@ git am --abort || true
 if git show-ref refs/heads/release; then
     git checkout release
 else
-    git checkout -b release
+    git checkout -b release upstream/release || git checkout -b release
 fi
 git reset --hard
 

--- a/jdk8u/merge.sh
+++ b/jdk8u/merge.sh
@@ -247,7 +247,11 @@ commitId=$(git rev-list -n 1  $tag)
 cd "$REPO"
 git merge --abort || true
 git rebase --abort || true
-git checkout $workingBranch || git checkout -b $workingBranch
+if git rev-parse -q --verify "$workingBranch" ; then
+  git checkout $workingBranch
+else
+  git checkout -b $workingBranch upstream/$workingBranch || git checkout -b $workingBranch
+fi
 
 # Get rid of existing tag that we are about to create
 if [ "$doTagging" == "true" ]; then


### PR DESCRIPTION
The merge script was always creating the target branch (eg.release) from master if it did not exist locally.

Signed-off-by: Andrew Leonard <anleonar@redhat.com>