### PR TITLE
Correct potential problem with stable tag sort after build level sort

### DIFF
--- a/mercurialToGit.sh
+++ b/mercurialToGit.sh
@@ -88,7 +88,7 @@ fi
 jdk11plus_tag_sort1="sort -t+ -k2,2n"
 # Second, (stable) sort on (V), (W), (X), (P): P(Patch) is optional and defaulted to "0"
 jdk11plus_tag_sort2="sort -t. -k2,2n -k3,3n -k4,4n -k5,5n"
-jdk11plus_sort_tags_cmd="grep -v _openj9 | grep -v _adopt | sed 's/jdk-/jdk./g' | sed 's/+/.0.+/g' | $jdk11plus_tag_sort1 | nl | $jdk11plus_tag_sort2 | sed 's/\.0\.+/+/g' | cut -f2- | sed 's/jdk./jdk-/g'"
+jdk11plus_sort_tags_cmd="grep -v _openj9 | grep -v _adopt | sed 's/jdk-/jdk./g' | sed 's/+/.0.+/g' | $jdk11plus_tag_sort1 | nl -n rz | $jdk11plus_tag_sort2 | sed 's/\.0\.+/+/g' | cut -f2- | sed 's/jdk./jdk-/g'"
 
 
 function cloneGitHubRepo() {

--- a/skaraMirror.sh
+++ b/skaraMirror.sh
@@ -200,7 +200,7 @@ TAG_SEARCH="jdk-${GITHUB_REPO//[!0-9]/}*+*"
 jdk11plus_tag_sort1="sort -t+ -k2,2n"
 # Second, (stable) sort on (V), (W), (X), (P): P(Patch) is optional and defaulted to "0"
 jdk11plus_tag_sort2="sort -t. -k2,2n -k3,3n -k4,4n -k5,5n"
-jdk11plus_sort_tags_cmd="grep -v _adopt | sed 's/jdk-/jdk./g' | sed 's/+/.0.0+/g' | $jdk11plus_tag_sort1 | nl | $jdk11plus_tag_sort2 | sed 's/\.0\.0+/+/g' | cut -f2- | sed 's/jdk./jdk-/g'"
+jdk11plus_sort_tags_cmd="grep -v _adopt | sed 's/jdk-/jdk./g' | sed 's/+/.0.0+/g' | $jdk11plus_tag_sort1 | nl -n rz | $jdk11plus_tag_sort2 | sed 's/\.0\.0+/+/g' | cut -f2- | sed 's/jdk./jdk-/g'"
 
 cloneGitHubRepo
 addSkaralUpstream


### PR DESCRIPTION
build issue https://github.com/adoptium/temurin-build/pull/2653
highlighted a potential problem with the stable tag 2nd sort if the 1st sort went over a 9-10 boundary due to line numbering with no 0 padding causing wrong sort order, eg:
8
9
10
11
=>
10
11
8
9

mirror scripts need to sort the whole list to pull all sets of new tags, so i've taken the approach here of using "nl -n rz" to 0 extend the line numbering.
000008
000009
000010
000011
sorts correctly

Signed-off-by: Andrew Leonard <anleonar@redhat.com>