### PR TITLE
Update -ga release trigger script to check previous scmReference that was triggered

### DIFF
--- a/common.sh
+++ b/common.sh
@@ -41,16 +41,15 @@ function queryGHAPI(){
   echo ${exist}
 }
 
-# to check if the same tag has been used to triggere release pipeline
+# to check if the same _adopt scmReference tag has been used to trigger a release pipeline in the past
 # if yes, wont trigger; if not, do the first time trigger
 function checkPrevious() {
   if [ -f ${WORKSPACE}/tracking ]; then # already have tracking from previous
     expectedTag=$1 #
     trackerTag="$(cut -d '=' -f 2 ${WORKSPACE}/tracking)" # previousSCM=jdk-17.0.5+8_adopt
-    olderTag="$(echo -e "${expectedTag}\n${trackerTag}" | sort -V | head -n1)"
 
-    if [[ "${expectedTag}" == "${olderTag}" || "${expectedTag}" == "${trackerTag}" ]]; then
-        echo "Release tag ${trackerTag} has been used in the current release"
+    if [[ "${expectedTag}" == "${trackerTag}" ]]; then
+        echo "Release tag ${trackerTag} has triggered a release pipeline build already in the current release"
         echo "Will not continue job"
         exit 0
     fi

--- a/triggerReleasePipeline.sh
+++ b/triggerReleasePipeline.sh
@@ -26,7 +26,7 @@ set -euo pipefail
 
 JDKVERSION="$1"
 ADOPTIUM_REPO=${2:-"https://github.com/adoptium/$JDKVERSION.git"}
-BRANCH=${3:-master"}
+BRANCH=${3:-"master"}
 
 # Since we have "jdk8u" in the code, we need to create another lever of "workspace"
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
@@ -48,9 +48,6 @@ cloneGitHubRepo $ADOPTIUM_REPO
 
 # read expectedTag from cfg file (releasePlan.cfg) to see if this is the correct GA tag we want for release
 expectedTag=$(readExpectedGATag $JDKVERSION)
-
-# check if we need to proceed when expectedTag already get matched and triggered release pipeline in the past
-checkPrevious ${expectedTag}
 
 # fetch all new refs including tags from origin remote
 cd "$WORKSPACE/$JDKVERSION"
@@ -79,6 +76,10 @@ scmReferenceList=($scmReferenceString)
 
 # append _adopt => release tag we use in adoptium
 scmReference="${scmReferenceList[0]}_adopt"
+
+# check if we need to proceed when scmReference has already triggered release pipeline in the past
+checkPrevious ${scmReference}
+
 # loop with 10m sleep if git-mirror has not applied the _adopt tag or if there is a merge conflict in git-mirror that we need to manual resolve
 for i in {1..5}
 do


### PR DESCRIPTION
The release -ga tag trigger script was checking against any previous release trigger by just the ga release tag "jdk-17.0.6-ga", this meant we could not distinguish against any before release test tag triggers.

This PR updates the checkPrevious() logic to check against the previous built scmReference for this release.

Signed-off-by: Andrew Leonard <anleonar@redhat.com>