### PR TITLE
expectedTag gets overwritten by checkPrevious scmReference

### DIFF
--- a/common.sh
+++ b/common.sh
@@ -45,10 +45,10 @@ function queryGHAPI(){
 # if yes, wont trigger; if not, do the first time trigger
 function checkPrevious() {
   if [ -f ${WORKSPACE}/tracking ]; then # already have tracking from previous
-    expectedTag=$1 #
+    scmRef=$1 # _adopt scmReference tag we have found
     trackerTag="$(cut -d '=' -f 2 ${WORKSPACE}/tracking)" # previousSCM=jdk-17.0.5+8_adopt
 
-    if [[ "${expectedTag}" == "${trackerTag}" ]]; then
+    if [[ "${scmRef}" == "${trackerTag}" ]]; then
         echo "Release tag ${trackerTag} has triggered a release pipeline build already in the current release"
         echo "Will not continue job"
         exit 0

--- a/common.sh
+++ b/common.sh
@@ -45,8 +45,8 @@ function queryGHAPI(){
 # if yes, wont trigger; if not, do the first time trigger
 function checkPrevious() {
   if [ -f ${WORKSPACE}/tracking ]; then # already have tracking from previous
-    scmRef=$1 # _adopt scmReference tag we have found
-    trackerTag="$(cut -d '=' -f 2 ${WORKSPACE}/tracking)" # previousSCM=jdk-17.0.5+8_adopt
+    local scmRef=$1 # _adopt scmReference tag we have found
+    local trackerTag="$(cut -d '=' -f 2 ${WORKSPACE}/tracking)" # previousSCM=jdk-17.0.5+8_adopt
 
     if [[ "${scmRef}" == "${trackerTag}" ]]; then
         echo "Release tag ${trackerTag} has triggered a release pipeline build already in the current release"

--- a/triggerReleasePipeline.sh
+++ b/triggerReleasePipeline.sh
@@ -48,6 +48,7 @@ cloneGitHubRepo $ADOPTIUM_REPO
 
 # read expectedTag from cfg file (releasePlan.cfg) to see if this is the correct GA tag we want for release
 expectedTag=$(readExpectedGATag $JDKVERSION)
+echo "Expected release tag: ${expectedTag}"
 
 # fetch all new refs including tags from origin remote
 cd "$WORKSPACE/$JDKVERSION"


### PR DESCRIPTION
Found a bug in testing:
The checkPrevious function uses the expectTag variable name, which in fact is now the scmReference, but unfortunately this overrides the expectedTag global variable value.

Signed-off-by: Andrew Leonard <anleonar@redhat.com>