### PR TITLE
Skip fork point build tags -b00 and +0

### DIFF
--- a/skaraMirror.sh
+++ b/skaraMirror.sh
@@ -123,6 +123,10 @@ function performMergeIntoReleaseFromMaster() {
         fi
       done
     fi
+    if [[ "$tag" == *\-b00 ]] || [[ "$tag" == *\+0 ]]; then
+        echo "Skipping fork point tag $tag from current list"
+        skipThisTag=true
+    fi
     if [[ "$skipThisTag" == false ]]; then
       currentReleaseTag="$tag"
     fi
@@ -149,6 +153,10 @@ function performMergeIntoReleaseFromMaster() {
            echo "Skipping merge of excluded tag $tag"
           fi
         done
+      fi
+      if [[ "$tag" == *\-b00 ]] || [[ "$tag" == *\+0 ]]; then
+          echo "Skipping merge of fork point tag $tag"
+          mergeTag=false
       fi
       if [[ "$mergeTag" == true ]]; then
         echo "Merging build tag $tag into release branch"
@@ -178,6 +186,10 @@ function performMergeIntoReleaseFromMaster() {
           skipThisTag=true
         fi
       done
+    fi
+    if [[ "$tag" == *\-b00 ]] || [[ "$tag" == *\+0 ]]; then
+        echo "Skipping fork point tag $tag from current list"
+        skipThisTag=true
     fi
     if [[ "$skipThisTag" == false ]]; then
       prevReleaseTag="${currentReleaseTag}"


### PR DESCRIPTION
Fixes https://github.com/adoptium/mirror-scripts/issues/37

When upstream repo forks a release eg.jdk8u392 from jdk8u382, a jdk8u392-b00 tag is created to mark the fork point, similarly for jdk-20.0.2 from jdk-20.0.1 a jdk-20.0.2+0 is created. These are not build tags to build from, and are just to mark the fork.
As the fork point tag appears down both views of the git tree, it causes the tag ordering to go wrong as for example jdk-20.0.2+0 which would be visible before jdk-20.0.1+9 even exist to be taken as the latest tag, and thus 20.0.1 tags then are prevented from being mirrored....
