### PR TITLE
Update releasePlan.cfg for July 2023 releases

### DIFF
--- a/releasePlan.cfg
+++ b/releasePlan.cfg
@@ -7,7 +7,7 @@
 #jdk-17.0.7-beforereleastest-ga
 #jdk-20.0.1-beforereleastest-ga
 
-jdk8uGA="jdk8u371"
-jdk11uGA="jdk-11.0.19"
-jdk17uGA="jdk-17.0.7"
-jdk20uGA="jdk-20.0.1"
+jdk8uGA="jdk8u382"
+jdk11uGA="jdk-11.0.20"
+jdk17uGA="jdk-17.0.8"
+jdk20uGA="jdk-20.0.2"


### PR DESCRIPTION
Note: JDK20 has been set to the desired GA level but it is not one with a valid tag so cannot be used for the dry-run trigger test