### PR TITLE
Update GA versions for Jan 2024 release

### DIFF
--- a/releasePlan.cfg
+++ b/releasePlan.cfg
@@ -8,8 +8,8 @@
 #jdk-17.0.7-dryrun-ga
 #jdk-20.0.1-dryrun-ga
 
-jdk8uGA="jdk8u392"
-jdk11uGA="jdk-11.0.21"
-jdk17uGA="jdk-17.0.9"
-jdk21uGA="jdk-21.0.1"
+jdk8uGA="jdk8u402"
+jdk11uGA="jdk-11.0.22"
+jdk17uGA="jdk-17.0.10"
+jdk21uGA="jdk-21.0.2"
 


### PR DESCRIPTION
Using https://www.java.com/releases/ as a guide

`2024-01-16 | CPU |   | 21.0.2, 17.0.10, 11.0.22, 8u401`
