### PR TITLE
Allow branch to be overridden by an env var

### DIFF
--- a/skaraMirror.sh
+++ b/skaraMirror.sh
@@ -273,7 +273,7 @@ checkArgs $#
 SKARA_REPO="https://github.com/openjdk/$1"
 GITHUB_REPO="$1"
 REPO=${2:-"git@github.com:adoptium/$GITHUB_REPO"}
-BRANCH={BRANCH:=master}
+BRANCH=${BRANCH:=master}
 
 GITHUB_REPO_REMOVE_aarch32=${GITHUB_REPO#"aarch32"}
 VERSION=${GITHUB_REPO_REMOVE_aarch32//[!0-9]/}

--- a/skaraMirror.sh
+++ b/skaraMirror.sh
@@ -273,7 +273,7 @@ checkArgs $#
 SKARA_REPO="https://github.com/openjdk/$1"
 GITHUB_REPO="$1"
 REPO=${2:-"git@github.com:adoptium/$GITHUB_REPO"}
-: ${BRANCH:="master"}
+BRANCH={BRANCH:=master}
 
 GITHUB_REPO_REMOVE_aarch32=${GITHUB_REPO#"aarch32"}
 VERSION=${GITHUB_REPO_REMOVE_aarch32//[!0-9]/}

--- a/skaraMirror.sh
+++ b/skaraMirror.sh
@@ -273,7 +273,7 @@ checkArgs $#
 SKARA_REPO="https://github.com/openjdk/$1"
 GITHUB_REPO="$1"
 REPO=${2:-"git@github.com:adoptium/$GITHUB_REPO"}
-BRANCH="master"
+: ${BRANCH:="master"}
 
 GITHUB_REPO_REMOVE_aarch32=${GITHUB_REPO#"aarch32"}
 VERSION=${GITHUB_REPO_REMOVE_aarch32//[!0-9]/}


### PR DESCRIPTION
This is required for the jdk11u risc-v port mirror which doesn't use the master branch

see https://github.com/adoptium/temurin-build/issues/3677