### PR TITLE
releasePlan: Switch jdk22 -> 22u and set tag suitable for dryrun

### DIFF
--- a/releasePlan.cfg
+++ b/releasePlan.cfg
@@ -12,5 +12,5 @@ jdk8uGA="jdk8u412"
 jdk11uGA="jdk-11.0.23"
 jdk17uGA="jdk-17.0.11"
 jdk21uGA="jdk-21.0.3"
-jdk22GA="jdk-22"
+jdk22uGA="jdk-22.0.0"
 


### PR DESCRIPTION
The latest STS releases do not have regular tags, therefore the dryrun build cannot be performed on this release as https://github.com/adoptium/mirror-scripts/blob/dbd2da02708084d38f4cb57efd93ea0905aa870e/triggerReleasePipeline.sh#L63 expects there to be a "real" `_adopt` tag matching the `-dryrun-ga` one.

I am making this update with the intention of creating and pushing a `jdk-22.0.0+0` which points to the same commit as `jdk-22.0.0-dryrun-ga` and will therefore allow the dryrun to progress. I'm choosing 22.0.0+0 as it will not interfere with (1) The current jdk-22+xx tags or (2) Future jdk-22.0.1+xx tags.

This will need to be switched over to 22.0.1 once the dryrun is complete and we prep for the GA.