### PR TITLE
Update skaraMirror.sh to handle upstream jdk(head) version branching

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ Historical information about the migration to OpenJDK GitHub from Mercurial is a
 The script merges the appropriate latest merged "master" branch code into both "dev" and "release", it also ensures all the
 "Adoptium Patches" from the "release" branch are merged into the "dev" branch.
 
+The BRANCH environment variable defines the upstream master branch name, and defaults to "master" if not specified. The dev and release
+mirror branches default to "dev" and "release" for "master", for other master branches they are "dev_$BRANCH" and "release_$BRANCH". This is to support
+the new upstream OpenJDK head repository stabilization version branches (eg.jdk23, would use mirror branches dev_jdk23 and release_jdk23).
+
 The flow for the merge process is:
 ```mermaid
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The script merges the appropriate latest merged "master" branch code into both "
 
 The BRANCH environment variable defines the upstream master branch name, and defaults to "master" if not specified. The dev and release
 mirror branches default to "dev" and "release" for "master", for other master branches they are "dev_$BRANCH" and "release_$BRANCH". This is to support
-the new upstream OpenJDK head repository stabilization version branches (eg.jdk23, would use mirror branches dev_jdk23 and release_jdk23).
+the new upstream OpenJDK head repository stabilization version branches (e.g., `jdk23`, would use mirror branches `dev_jdk23` and `release_jdk23`).
 
 The flow for the merge process is:
 ```mermaid

--- a/patches/actions-ignore-branches.patch
+++ b/patches/actions-ignore-branches.patch
@@ -16,8 +16,8 @@ index ec7e3c9957b..cac8a36dcaf 100644
    push:
      branches-ignore:
        - master
-+      - dev
-+      - release
++      - dev*
++      - release*
        - pr/*
        - jdk*
    workflow_dispatch:


### PR DESCRIPTION
Fixes https://github.com/adoptium/temurin-build/issues/3841

Fixes the Adoptium mirror to handle upstream OpenJDK version branches.

- Now the BRANCH environmental variable can be set to a non-master branch, eg.jdk23
- This causes the mirror to mirror the upstream jdk23 branch to the same within the mirror, and also merge into dev and release branches called:
  - dev_$BRANCH
  - release_$BRANCH

The behaviour after this change, is not changed if BRANCH is not set or is value "master".

After this change is merged, the jdk(head) mirror Jenkins job shell script will be updated to the following:
```
export releaseTagExcludeList=""

branches="master jdk23"

for branch in $branches
do
  export BRANCH="$branch"
  bash ./skaraMirror.sh jdk
done
```
 