### PR TITLE
Make sure mirror version branching only enabled for jdk(head)

### DIFF
--- a/skaraMirror.sh
+++ b/skaraMirror.sh
@@ -269,7 +269,15 @@ GITHUB_REPO="$1"
 REPO=${2:-"git@github.com:adoptium/$GITHUB_REPO"}
 BRANCH=${BRANCH:=master}
 
-if [[ "${BRANCH}" == "master" ]]; then
+# Does this OpenJDK repo support verion branching?
+VERSION_BRANCHING=false
+
+# jdk(head) is only repository currently supporting version branches
+if [[ "${GITHUB_REPO}" == "jdk" ]]; then
+  VERSION_BRANCHING=true
+fi
+
+if [[ "${VERSION_BRANCHING}" == false ]] || [[ "${BRANCH}" == "master" ]]; then
   RELEASE_BRANCH="release"
   DEV_BRANCH="dev"
 else

--- a/skaraMirror.sh
+++ b/skaraMirror.sh
@@ -269,7 +269,7 @@ GITHUB_REPO="$1"
 REPO=${2:-"git@github.com:adoptium/$GITHUB_REPO"}
 BRANCH=${BRANCH:=master}
 
-# Does this OpenJDK repo support verion branching?
+# Does this OpenJDK repo support version branching?
 VERSION_BRANCHING=false
 
 # jdk(head) is only repository currently supporting version branches


### PR DESCRIPTION
The riscv-jdk11u mirror was broken by the version branching change, as that repo uses a main branch called "riscv-port",
the assumption all branches of NOT named "master" are version branches is not accurate.

This PR updates the version branching check to only enable for "jdk" (head) github repo.
