### PR TITLE
Update JDK tags for Jan 2025 dryrun

### DIFF
--- a/releasePlan.cfg
+++ b/releasePlan.cfg
@@ -8,8 +8,8 @@
 #jdk-17.0.7-dryrun-ga
 #jdk-20.0.1-dryrun-ga
 
-jdk8uGA="jdk8u432-ga"
-jdk11uGA="jdk-11.0.25-ga"
-jdk17uGA="jdk-17.0.13-ga"
-jdk21uGA="jdk-21.0.5-ga"
-jdk23uGA="jdk-23.0.1-ga"
+jdk8uGA="jdk8u442-dryrun-ga"
+jdk11uGA="jdk-11.0.26-dryrun-ga"
+jdk17uGA="jdk-17.0.14-dryrun-ga"
+jdk21uGA="jdk-21.0.6-dryrun-ga"
+jdk23uGA="jdk-23.0.1-dryrun-ga"


### PR DESCRIPTION
There is no jdk-23.0.2 tag in https://github.com/adoptium/jdk23u/tags, so we can use jdk-23.0.1 for the dryrun