### PR TITLE
Remove dryrun tags in prep for January 2025 release

### DIFF
--- a/releasePlan.cfg
+++ b/releasePlan.cfg
@@ -8,8 +8,8 @@
 #jdk-17.0.7-dryrun-ga
 #jdk-20.0.1-dryrun-ga
 
-jdk8uGA="jdk8u442-dryrun-ga"
-jdk11uGA="jdk-11.0.26-dryrun-ga"
-jdk17uGA="jdk-17.0.14-dryrun-ga"
-jdk21uGA="jdk-21.0.6-dryrun-ga"
-jdk23uGA="jdk-23.0.2-dryrun-ga"
+jdk8uGA="jdk8u442-ga"
+jdk11uGA="jdk-11.0.26-ga"
+jdk17uGA="jdk-17.0.14-ga"
+jdk21uGA="jdk-21.0.6-ga"
+jdk23uGA="jdk-23.0.2-ga"


### PR DESCRIPTION
Wont be kicking off anymore dryrun pipelines, prep the tags for the GA release