### PR TITLE
Update releasePlan.cfg for April 2025

### DIFF
--- a/releasePlan.cfg
+++ b/releasePlan.cfg
@@ -8,9 +8,8 @@
 #jdk-17.0.7-dryrun-ga
 #jdk-20.0.1-dryrun-ga
 
-jdk8uGA="jdk8u442-ga"
-jdk11uGA="jdk-11.0.26-ga"
-jdk17uGA="jdk-17.0.14-ga"
-jdk21uGA="jdk-21.0.6-ga"
-jdk23uGA="jdk-23.0.2-ga"
-jdk24GA="jdk-24-ga"
+jdk8uGA="jdk8u452-dryrun-ga"
+jdk11uGA="jdk-11.0.27-dryrun-ga"
+jdk17uGA="jdk-17.0.15-dryrun-ga"
+jdk21uGA="jdk-21.0.7-dryrun-ga"
+jdk24uGA="jdk-24.0.1-dryrun-ga"


### PR DESCRIPTION
April 2025 dry runs:
jdk8uGA="jdk8u452-dryrun-ga"
jdk11uGA="jdk-11.0.27-dryrun-ga"
jdk17uGA="jdk-17.0.15-dryrun-ga"
jdk21uGA="jdk-21.0.7-dryrun-ga"
jdk24uGA="jdk-24.0.1-dryrun-ga"
